### PR TITLE
fix(trivy): add --platform linux/amd64 for multi-arch scanning

### DIFF
--- a/actions/trivy-scan/action.yml
+++ b/actions/trivy-scan/action.yml
@@ -74,6 +74,7 @@ runs:
         echo "🔍 Scanning image: ${{ inputs.image }}"
 
         # Run Trivy scan with credentials via env vars
+        # Note: Multi-arch manifests require platform specification
         trivy image \
           --format ${{ inputs.format }} \
           --output ${{ inputs.output_file }} \
@@ -81,6 +82,7 @@ runs:
           --exit-code ${{ inputs.exit_code }} \
           --vuln-type os,library \
           --scanners vuln,secret,config \
+          --platform linux/amd64 \
           --timeout 10m \
           ${{ inputs.image }}
 


### PR DESCRIPTION
## 🔧 Trivy Multi-Arch Fix

Add `--platform linux/amd64` flag to Trivy scan to fix multi-architecture manifest scanning.

### Problem
Trivy scan failing with:
```
remote error: no child with platform linux/amd64 in index 
ghcr.io/marcelpiva-org/maestro-knowledge-app:develop-165a48d
```

### Root Cause
- We create multi-arch manifests (AMD64 + ARM64)
- Trivy was trying to scan the manifest without specifying platform
- Multi-arch manifests require platform specification to pull specific image

### Solution
Add `--platform linux/amd64` flag to Trivy command:

```yaml
trivy image \
  --platform linux/amd64 \
  --format sarif \
  ...
  ghcr.io/marcelpiva-org/maestro-knowledge-app:latest
```

### How it works
1. Trivy receives multi-arch manifest from GHCR
2. With `--platform linux/amd64`, Trivy pulls AMD64 variant
3. Scans the specific platform image
4. Uploads SARIF results to Security tab

### Testing
- [x] Flag added to Trivy CLI command
- [x] Syntax validated
- [ ] Will validate on next pipeline run

### Related
- Previous fix: Added `packages:read` permission (#2)
- This fix: Platform specification for multi-arch manifests

### Part of
DevSecOps Phase 2 - Security Scanning (Task 2.4 - Final Fix)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)