### PR TITLE
feat(ci-fast): restore Gitleaks action with license support

### DIFF
--- a/.github/workflows/dotnet-ci-fast.yml
+++ b/.github/workflows/dotnet-ci-fast.yml
@@ -177,20 +177,12 @@ jobs:
       with:
         fetch-depth: 0  # Full history for secret scanning
 
-    - name: 🔍 Secret Scanning (Gitleaks CLI)
-      run: |
-        echo "🔍 Installing Gitleaks CLI..."
-        wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz
-        tar -xzf gitleaks_8.18.2_linux_x64.tar.gz
-        chmod +x gitleaks
-
-        echo "🔍 Scanning for secrets..."
-        ./gitleaks detect --source . --verbose --no-git || {
-          echo "❌ Secrets detected! Please review and remove them."
-          exit 1
-        }
-
-        echo "✅ No secrets detected"
+    - name: 🔍 Secret Scanning (Gitleaks)
+      uses: gitleaks/gitleaks-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        GITLEAKS_ENABLE_COMMENTS: false
 
     - name: 📦 Dependency Vulnerability Scan
       run: |


### PR DESCRIPTION
## Changes

Restore `gitleaks-action@v2` with license support.

## License Key

License obtained from gitleaks.io:
```
35D640-EBBDB7-486C41-754D93-4B2401-V3
```

## Setup Required

Add the license as an **organization-level secret**:

1. Go to https://github.com/organizations/marcelpiva-org/settings/secrets/actions
2. Click "New organization secret"
3. Name: `GITLEAKS_LICENSE`
4. Value: `35D640-EBBDB7-486C41-754D93-4B2401-V3`
5. Repository access: **All repositories** (or select specific repos)

## Testing

After adding the secret, the CI Fast workflow should pass the Gitleaks step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)