### PR TITLE
fix(workflows): replace env context with github context in CI Heavy

### DIFF
--- a/.github/workflows/dotnet-ci-heavy.yml
+++ b/.github/workflows/dotnet-ci-heavy.yml
@@ -429,7 +429,7 @@ jobs:
     name: ⏸️ Approve Staging Deployment
     runs-on: ubuntu-latest
     needs: [setup-and-version, create-manifest, security-scan, performance-tests, load-tests]
-    if: ${{ env.IS_RELEASE_BRANCH == 'true' && inputs.deploy_to_staging }}
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') && inputs.deploy_to_staging }}
     environment:
       name: staging-approval
       url: https://${{ inputs.service_name }}-staging.maestroai
@@ -466,7 +466,7 @@ jobs:
     name: 🚀 Deploy to Staging
     runs-on: ubuntu-latest
     needs: [setup-and-version, approve-staging-deployment]
-    if: ${{ env.IS_RELEASE_BRANCH == 'true' && inputs.deploy_to_staging }}
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') && inputs.deploy_to_staging }}
 
     steps:
     - name: 📥 Checkout infrastructure
@@ -503,7 +503,7 @@ jobs:
     name: 📝 Create GitHub Release
     runs-on: ubuntu-latest
     needs: [setup-and-version, create-manifest, deploy-staging]
-    if: ${{ (env.IS_MAIN_BRANCH == 'true' || env.IS_RELEASE_BRANCH == 'true') && inputs.enable_semantic_release }}
+    if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.enable_semantic_release }}
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

Fix CI Heavy workflow failure caused by invalid use of `env` context in job-level `if` conditions.

## Issue

- CI Heavy workflow failed immediately (0s duration) with "workflow file issue" error
- Blocked Scenario 5 testing (Release Branch → CI Heavy + Deploy Staging)

## Root Cause

GitHub Actions **does not support `env` context in job-level `if` conditions**. The `env` context is only available within steps, not at the job level.

**Invalid usage** (lines 432, 469, 506):
```yaml
if: ${{ env.IS_RELEASE_BRANCH == 'true' && inputs.deploy_to_staging }}
if: ${{ env.IS_MAIN_BRANCH == 'true' || env.IS_RELEASE_BRANCH == 'true' }}
```

## Solution

Replace `env` variables with `github` context checks that work at job level:

```yaml
# Before
if: ${{ env.IS_RELEASE_BRANCH == 'true' && inputs.deploy_to_staging }}

# After
if: ${{ startsWith(github.ref, 'refs/heads/release/') && inputs.deploy_to_staging }}
```

## Changes

- **Line 432**: `approve-staging-deployment` job - Use `startsWith(github.ref, 'refs/heads/release/')`
- **Line 469**: `deploy-staging` job - Use `startsWith(github.ref, 'refs/heads/release/')`  
- **Line 506**: `create-release` job - Use `github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')`

## Testing

- [x] YAML syntax validated
- [x] Job-level `if` conditions use only `github` context
- [ ] Will be tested in Scenario 5 after merge

## Impact

Unblocks CI Heavy workflow execution for:
- Release branches (`release/*`)
- Main branch
- Hotfix branches (`hotfix/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)